### PR TITLE
Nereid-auth-facebook migration to 2.4.0.8 #678

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@
 
     Facebook Graph based authentication for nereid
 
-    :copyright: (c) 2012 by Openlabs Technologies & Consulting (P) LTD
+    :copyright: (c) 2012-2013 by Openlabs Technologies & Consulting (P) LTD
     :license: GPLv3, see LICENSE for more details.
 """
 from user import *

--- a/__tryton__.py
+++ b/__tryton__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Nereid Facebook Auth',
-    'version': '2.4.0.1dev',
+    'version': '2.4.0.2dev',
     'author': 'Openlabs Technologies & Consulting (P) Ltd.',
     'email': 'info@openlabs.co.in',
     'website': 'http://www.openlabs.co.in/',

--- a/setup.py
+++ b/setup.py
@@ -60,4 +60,3 @@ setup(name='trytond_%s' % module_name,
     test_suite='tests',
     test_loader='trytond.test_loader:Loader',
 )
-

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""
+    __init__
+
+    Test Suite for the BCI module
+
+    :copyright: © 2013 by Openlabs Technologies & Consulting (P) Limited
+    :license: BSD, see LICENSE for more details.
+"""
+import unittest
+
+import trytond.tests.test_tryton
+
+from .test_facebook_login import TestFacebookAuth
+
+
+def suite():
+    test_suite = trytond.tests.test_tryton.suite()
+    test_suite.addTests([
+        unittest.TestLoader().loadTestsFromTestCase(TestFacebookAuth)
+    ])
+    return test_suite

--- a/tests/test_facebook_login.py
+++ b/tests/test_facebook_login.py
@@ -4,7 +4,7 @@
 
     Test the facebook login
 
-    :copyright: (c) 2012 by Openlabs Technologies & Consulting (P) LTD
+    :copyright: (c) 2012-2013 by Openlabs Technologies & Consulting (P) LTD
     :license: GPLv3, see LICENSE for more details.
 """
 import os
@@ -14,17 +14,14 @@ import urlparse
 import threading
 import webbrowser
 from StringIO import StringIO
-
 from lxml import etree
-from trytond.config import CONFIG
-CONFIG.options['db_type'] = 'sqlite'
-from trytond.modules import register_classes
-register_classes()
-from nereid.testing import testing_proxy, TestCase
-from trytond.transaction import Transaction
-from trytond.pool import Pool
 
-_def = []
+import trytond.tests.test_tryton
+from trytond.tests.test_tryton import POOL, USER, DB_NAME, CONTEXT, \
+    test_view, test_depends
+from nereid.testing import NereidTestCase
+from trytond.transaction import Transaction
+
 def get_from_env(key):
     """
     Find a value from environ or return the default if specified
@@ -59,95 +56,121 @@ class FacebookHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         return
 
 
-class TestFacebookAuth(TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestFacebookAuth, cls).setUpClass()
-        # Install module
-        testing_proxy.install_module('nereid_auth_facebook')
-
-        with Transaction().start(testing_proxy.db_name, 1, None) as txn:
-            country_obj = Pool().get('country.country')
-            currency_obj = Pool().get('currency.currency')
-
-            company = testing_proxy.create_company('Test Company')
-            testing_proxy.set_company_for_user(1, company)
-
-            cls.guest_user = testing_proxy.create_guest_user(company=company)
-            cls.regd_user_id = testing_proxy.create_user_party(
-                'Registered User', 'email@example.com', 'password', company
-            )
-
-            cls.available_countries = country_obj.search([], limit=5)
-            cls.available_currencies = currency_obj.search([
-                ('code', '=', 'USD')
-            ])
-
-            cls.site = testing_proxy.create_site(
-                'localhost',
-                countries = [('set', cls.available_countries)],
-                currencies = [('set', cls.available_currencies)],
-                application_user = 1,
-                guest_user = cls.guest_user,
-            )
-
-            testing_proxy.create_template(
-                'home.jinja', '{{ get_flashed_messages() }}', cls.site
-            )
-            testing_proxy.create_template(
-                'login.jinja',
-                '{{ login_form.errors }} {{ get_flashed_messages() }}',
-                cls.site
-            )
-            txn.cursor.commit()
-
-    def get_app(self, **options):
-        return testing_proxy.make_app(SITE='localhost', **options)
+class TestFacebookAuth(NereidTestCase):
 
     def setUp(self):
-        self.nereid_user_obj = testing_proxy.pool.get('nereid.user')
-        self.website_obj = testing_proxy.pool.get('nereid.website')
+        trytond.tests.test_tryton.install_module('nereid_auth_facebook')
+        self.nereid_user_obj = POOL.get('nereid.user')
+        self.nereid_website_obj = POOL.get('nereid.website')
+        self.country_obj = POOL.get('country.country')
+        self.currency_obj = POOL.get('currency.currency')
+        self.company_obj = POOL.get('company.company')
+        self.url_map_obj = POOL.get('nereid.url_map')
+        self.language_obj = POOL.get('ir.lang')
+
+    def setup_defaults(self):
+        """
+        Setup the defaults
+        """
+        usd = self.currency_obj.create({
+            'name': 'US Dollar',
+            'code': 'USD',
+            'symbol': '$',
+        })
+        company_id = self.company_obj.create({
+            'name': 'Openlabs',
+            'currency': usd
+        })
+        guest_user = self.nereid_user_obj.create({
+            'name': 'Guest User',
+            'display_name': 'Guest User',
+            'email': 'guest@openlabs.co.in',
+            'password': 'password',
+            'company': company_id,
+        })
+        self.registered_user_id = self.nereid_user_obj.create({
+            'name': 'Registered User',
+            'display_name': 'Registered User',
+            'email': 'email@example.com',
+            'password': 'password',
+            'company': company_id,
+        })
+        url_map_id, = self.url_map_obj.search([], limit=1)
+        en_us, = self.language_obj.search([('code', '=', 'en_US')])
+        self.site = self.nereid_website_obj.create({
+            'name': 'localhost',
+            'url_map': url_map_id,
+            'company': company_id,
+            'application_user': USER,
+            'default_language': en_us,
+            'guest_user': guest_user,
+        })
+
+    def get_template_source(self, name):
+        """
+        Return templates
+        """
+        self.templates = {
+            'localhost/home.jinja': '{{ get_flashed_messages() }}',
+            'localhost/login.jinja':
+                '{{ login_form.errors }} {{ get_flashed_messages() }}'
+        }
+        return self.templates.get(name)
+
+    def test_0005_test_view(self):
+        """
+        Test the view
+        """
+        test_view('nereid_auth_facebook')
+
+    def test_0006_test_depends(self):
+        """
+        Test Depends
+        """
+        test_depends()
 
     def test_0010_login(self):
         """
         Check for login with the next argument without API settings
         """
-        app = self.get_app()
-        with app.test_client() as c:
-            response = c.get('/en_US/auth/facebook?next=/en_US')
-            self.assertEqual(response.status_code, 302)
-            # Redirect to the home page since
-            self.assertTrue(
-                '<a href="/en_US/login">/en_US/login</a>' in response.data
-            )
-            rv = c.get('/')
-            self.assertTrue(
-                'Facebook login is not available at the moment' in rv.data
-            )
+        with Transaction().start(DB_NAME, USER, CONTEXT):
+            self.setup_defaults()
+            app = self.get_app()
+
+            with app.test_client() as c:
+                response = c.get('/en_US/auth/facebook?next=/en_US')
+                self.assertEqual(response.status_code, 302)
+                # Redirect to the home page since
+                self.assertTrue(
+                    '<a href="/en_US/login">/en_US/login</a>' in response.data
+                )
+                rv = c.get('/')
+                self.assertTrue(
+                    'Facebook login is not available at the moment' in rv.data
+                )
 
     def test_0020_login(self):
         """
         Login with facebook settings
         """
-        with Transaction().start(testing_proxy.db_name, 1, None) as txn:
-            self.website_obj.write(self.site, {
+        with Transaction().start(DB_NAME, USER, CONTEXT):
+            self.setup_defaults()
+            self.nereid_website_obj.write(self.site, {
                 'facebook_app_id': get_from_env('FACEBOOK_APP_ID'),
                 'facebook_app_secret': get_from_env('FACEBOOK_APP_SECRET'),
             })
-            txn.cursor.commit()
 
-        app = self.get_app()
-        with app.test_client() as c:
-            response = c.get('/en_US/auth/facebook?next=/en_US')
-            self.assertEqual(response.status_code, 302)
-            self.assertTrue(
-                'https://www.facebook.com/dialog/oauth' in response.data
-            )
-            # send the user to the webbrowser and wait for a redirect
-            parser = etree.HTMLParser()
-            tree   = etree.parse(StringIO(response.data), parser)
-            webbrowser.open(tree.xpath('//p/a')[0].values()[0])
+            app = self.get_app()
+            with app.test_client() as c:
+                response = c.get('/en_US/auth/facebook?next=/en_US')
+                self.assertEqual(response.status_code, 302)
+                self.assertTrue(
+                    'https://www.facebook.com/dialog/oauth' in response.data
+                )
+                # send the user to the webbrowser and wait for a redirect
+                parser = etree.HTMLParser()
+                tree   = etree.parse(StringIO(response.data), parser)
+                webbrowser.open(tree.xpath('//p/a')[0].values()[0])
 
 
 def suite():

--- a/urls.xml
+++ b/urls.xml
@@ -6,6 +6,7 @@
             <field name="rule">/&lt;language&gt;/auth/facebook_authorized_login</field>
             <field name="endpoint">nereid.user.facebook_authorized_login</field>
             <field name="sequence" eval="100" />
+            <field name="http_method_get" eval="True"/>
             <field name="url_map" ref="nereid.default_url_map" />
         </record>
     
@@ -13,6 +14,7 @@
             <field name="rule">/&lt;language&gt;/auth/facebook</field>
             <field name="endpoint">nereid.user.facebook_login</field>
             <field name="sequence" eval="110" />
+            <field name="http_method_get" eval="True"/>
             <field name="url_map" ref="nereid.default_url_map" />
         </record>
 


### PR DESCRIPTION
This patch migrates nereid-auth-facebook to version 2.4.0.8.
